### PR TITLE
Use our own update servlet for updates

### DIFF
--- a/electron-builder-publish.js
+++ b/electron-builder-publish.js
@@ -1,6 +1,11 @@
 const config = {
   publish: [
-      'github'
+    {
+      provider: 'generic',
+      url: 'https://www.sensotrend.fi/download/uploader/update/${os}',
+      channel: 'latest',
+      useMultipleRangeRequest: false
+    },
   ],
   productName: 'Sensotrend Uploader',
   appId: 'org.sensotrend.SensotrendUploader',


### PR DESCRIPTION
Not the GitHub, which is the default. We're not ready for that yet, and we see our update statistics better from our own server.