### PR TITLE
Accu-Chek / Roche SmartPix model 1 support for insulin pumps.

### DIFF
--- a/app/reducers/devices.js
+++ b/app/reducers/devices.js
@@ -13,6 +13,16 @@ const devices = {
     enabled: {mac: true, win: true, linux: true},
     powerOnlyWarning: true,  // shows warning for power-only USB cables
   },
+  accucheksmartpix: {
+    instructions: [
+      i18n.t('Ensure the Smart Pix is mounted before starting.'),
+      i18n.t('Click send and then start the transfer from your device.'),
+    ],
+    name: 'Roche Accu-Chek Smart Pix',
+    key: 'accucheksmartpix',
+    source: {type: 'device', driverId: 'AccuChekSmartPix'},
+    enabled: {mac: true, win: true, linux: true},
+  },
   carelink: {
     instructions: [i18n.t('Import from CareLink'), i18n.t('(We will not store your credentials)')],
     isFetching: false,

--- a/lib/core/device.js
+++ b/lib/core/device.js
@@ -52,6 +52,7 @@ import medtronicDriver from '../drivers/medtronic/medtronicDriver';
 import medtronic600Driver from '../drivers/medtronic600/medtronic600Driver';
 import TrueMetrixDriver from '../drivers/trividia/trueMetrix';
 import accuChekUSBDriver from '../drivers/roche/accuChekUSB';
+import accuChekSmartPixDriver from '../drivers/roche/accuChekSmartPix';
 import bluetoothLEDriver from '../drivers/bluetoothLE/bluetoothLEDriver';
 import careSensDriver from '../drivers/i-sens/careSens';
 import glucocardExpression from '../drivers/i-sens/glucocardExpression';
@@ -85,6 +86,7 @@ device.deviceDrivers = {
   Medtronic600: medtronic600Driver,
   TrueMetrix: TrueMetrixDriver,
   AccuChekUSB: accuChekUSBDriver,
+  AccuChekSmartPix: accuChekSmartPixDriver,
   BluetoothLE: bluetoothLEDriver,
   CareSens: careSensDriver,
   ReliOnPremier: careSensDriver,
@@ -111,6 +113,7 @@ device.deviceComms = {
   Medtronic600: hidDevice,
   TrueMetrix: hidDevice,
   AccuChekUSB: usbDevice,
+  AccuChekSmartPix: usbDevice,
   BluetoothLE: bleDevice,
   CareSens: hidDevice,
   ReliOnPremier: serialDevice,
@@ -259,6 +262,13 @@ device.driverManifests = {
       { vendorId: 5946, productId: 8661 }, // Accu-Chek Guide
       { vendorId: 5946, productId: 8655 }, // Accu-Chek Aviva Connect
       { vendorId: 5946, productId: 8662 }, // Accu-chek Guide Me
+    ],
+  },
+  AccuChekSmartPix: {
+    mode: 'usb',
+    label: 'SMART_PIX', // XXX: Not used yet.
+    usb: [
+      { vendorId: 5946, productId: 2106 }, // Accu-Chek Smart Pix Model 1
     ],
   },
   BluetoothLE: {

--- a/lib/drivers/roche/accuChekSmartPix.js
+++ b/lib/drivers/roche/accuChekSmartPix.js
@@ -1,0 +1,569 @@
+import fsCore from 'fs';
+import path from 'path';
+
+import _ from 'lodash';
+import sundial from 'sundial';
+import xml from 'xml2js';
+
+import annotate from '../../eventAnnotations';
+import TZOUtil from '../../TimezoneOffsetUtil';
+import { parsePumpData } from './smartpix/accuChekSmartPixPumpXML';
+
+const fs = fsCore.promises; // Current version doesn't have this public yet.
+const isBrowser = typeof window !== 'undefined';
+
+// eslint-disable-next-line no-console
+const log = isBrowser ? require('bows')('AccuChekSmartPixDriver') : console.log;
+
+/** Enable debug logging? */
+const AC_DEBUG = false;
+
+/**
+ * If true, some log will be printed, and an already read single report in the reader
+ * will not be re-read.
+ */
+const QUICK_SINGLE_REPORT = false;
+
+// eslint-disable-next-line no-console
+const debugLog = AC_DEBUG ? console.log : () => {};
+
+/**
+ * List files of directory.
+ *
+ * @param dirPath {string} Path to directory.
+ * @param match {string|RegExp?} Pattern to match files to return.
+ * @return {[{name: string, mtime: integer}]} List of files with modification times
+ *  in `dirPath` matching `match`.
+ */
+async function listDirFiles(dirPath, match) {
+  let matchExp = match;
+  if (typeof match === 'string') {
+    matchExp = new RegExp(match);
+  } else if (match === undefined) {
+    matchExp = null;
+  }
+
+  const dir = await fs.opendir(dirPath);
+
+  let aDir = await dir.read();
+  const foundFiles = [];
+  while (aDir != null) {
+    if (aDir.isFile() && (matchExp === null || matchExp.test(aDir.name))) {
+      // `for await` is not available and other choices need result from previous iteration.
+      // eslint-disable-next-line no-await-in-loop
+      const stat = await fs.stat(aDir.name);
+
+      foundFiles.push({
+        name: aDir.name,
+        mtime: stat.mtime,
+      });
+    }
+    // eslint-disable-next-line no-await-in-loop
+    aDir = await dir.read();
+  }
+
+  await dir.close();
+  return foundFiles;
+}
+
+/**
+ * @private
+ * Parse STATUS.TXT status line.
+ *
+ * @param line {string} The status line read from the file.
+ * @return {Object} Object containing status `.version` number and `.flags` as a list.
+ */
+function privateParseStatus(line) {
+  if (line === '') {
+    return {
+      version: 0,
+      flags: ['INTERNAL_ERROR'],
+    };
+  }
+  const pat = /(\d+|[\w,-]+(\([\w, -]+\))?)(?: |$)/g;
+  const parts = Array.from(line.matchAll(pat), (m) => m[1]);
+  return {
+    version: Number.parseInt(parts[0], 10),
+    flags: parts.slice(1),
+  };
+}
+
+/**
+ * @private
+ * Check if given pattern exists in status set.
+ *
+ * @param pattern {string|RegExp} Pattern to test.
+ *  Note, that if a string, it is compiled to RegExp.
+ * @param status {[string]} List of status flags.
+ * @returns {boolean} True if given pattern exists in status set. False if not.
+ */
+function privateIsInStatus(pattern, status) {
+  let exp = pattern;
+  if (typeof pattern === 'string') {
+    exp = new RegExp(pattern);
+  }
+  return _.find(status, (value) => exp.test(value)) !== undefined;
+}
+
+/**
+ * @private
+ * Check if given pattern is absent in status set.
+ *
+ * @param pattern {string|RegExp} Pattern to test. Note, that if a string, it is compiled to RegExp.
+ * @param status {[string]} List of status flags.
+ * @returns {boolean} True if given pattern does not exists in status set. False if it exists.
+ */
+function privateIsNotInStatus(pattern, status) {
+  let exp = pattern;
+  if (typeof pattern === 'string') {
+    exp = new RegExp(pattern);
+  }
+  return _.every(status, (value) => !exp.test(value));
+}
+
+/** Read a file, just ignoring the content. */
+async function privateReadFileIgnoreContent(filename) {
+  await fs.readFile(filename);
+}
+
+/**
+ * @private
+ * Resolve difference from two sets of file lists.
+ *
+ * @param first {[{name: string, mtime: integer}]} List of file-infos having `.name` and `.mtime`,
+ *  from {@link listDirFiles}.
+ * @param second {[{name: string, mtime: integer}]} List of file-infos having `.name` and `.mtime`,
+ *  from {@link listDirFiles}.
+ * @returns {[string]} List of new or changed files.
+ */
+function privateDiffReportLists(first, second) {
+  const firstFiles = _.map(first, (e) => e.name);
+  const secondFiles = _.map(second, (e) => e.name);
+  const firstLookup = new Map();
+  const secondLookup = new Map();
+  _.forEach(first, (e) => firstLookup.set(e.name, e.mtime));
+  _.forEach(second, (e) => secondLookup.set(e.name, e.mtime));
+
+  let changes = [];
+
+  const newFiles = _.difference(secondFiles, firstFiles);
+  changes = changes.concat(newFiles);
+
+  const existingFiles = _.intersection(secondFiles, firstFiles);
+  _.forEach(existingFiles, (existingFile) => {
+    const time1 = firstLookup.get(existingFile);
+    const time2 = secondLookup.get(existingFile);
+    if (time1 !== time2) {
+      changes.push(existingFile);
+    }
+  });
+
+  return changes;
+}
+
+class AccuChekSmartPix {
+  constructor(cfg) {
+    log('New instance');
+    this.cfg = cfg;
+    this.path = null;
+  }
+
+  setup(di) {
+    this.path = di.path;
+    this.reportPath = path.join(this.path, 'REPORT', 'XML');
+  }
+
+  /**
+   * @private
+   * Low-level function: Start a READ operation.
+   */
+  async privateLowRead() {
+    await this.privateReadTrgs('09', '00');
+  }
+
+  /**
+   * Read Smart Pix v1 trigger files to trigger an action.
+   *
+   * @param first {string} Two-digit number of first TRG image to read.
+   * @param second {string?} Optional two-digit number of second TRG image to read.
+   */
+  async privateReadTrgs(first, second) {
+    debugLog(`Read TRGs ${first}, ${second}`);
+    const base = path.join(this.path, 'TRG');
+    const f1 = path.join(base, `TRG${first}.PNG`);
+    await privateReadFileIgnoreContent(f1);
+
+    if (second !== undefined) {
+      const f2 = path.join(base, `TRG${second}.PNG`);
+      await privateReadFileIgnoreContent(f2);
+    }
+  }
+
+  /**
+   * @private
+   * Read current status values from the device.
+   *
+   * @return {Promise<Object>} Object containing status `.version` number and `.flags` as a list.
+   */
+  async privateReadStatus() {
+    const statusFileName = path.join(this.path, 'MISC', 'STATUS.TXT');
+    const content = await fs.readFile(statusFileName);
+    const text = _.trim(content.toString('utf-8'));
+    return privateParseStatus(text);
+  }
+
+  /**
+   * @private
+   * Wait for status to change.
+   *
+   * @param startVersion {integer} Current status version number to ignore.
+   * @param expect {string|RegExp?} Pattern to expect to appear or disappear from status flags.
+   * @param waitNot {boolean?} If falsy, pattern is expected to appear.
+   *  If truthy, pattern is expected to disappear.
+   * @param progress {Function?} Optional progress callback, called every 2s.
+   * @return {Promise<Object>} New status values (`.version`, `.flags`).
+   */
+  async privateWaitStatus(startVersion, expect, waitNot, progress) {
+    let pattern;
+    if (typeof expect === 'string') {
+      pattern = new RegExp(expect);
+    } else {
+      pattern = expect;
+    }
+    const waitFn = waitNot ? privateIsNotInStatus : privateIsInStatus;
+
+    log(`Waiting at ${startVersion} ${waitNot ? 'while exists' : 'until'} ${expect}`);
+
+    return new Promise((resolve, reject) => {
+      let prevVersion = startVersion;
+      let progressDivider = 0;
+      const loop = async () => {
+        try {
+          const status = await this.privateReadStatus();
+          if (prevVersion !== status.version) {
+            debugLog(`Wait version: ${status.version}: ${status.flags}`);
+            prevVersion = status.version;
+          }
+          if (progress) {
+            progressDivider += 1;
+            if (progressDivider >= 2) {
+              progressDivider = 0;
+              progress();
+            }
+          }
+          // If version hasn't increased,
+          // or if flags should be checked and the check fails,
+          // wait more.
+          if (status.version <= startVersion || (pattern && !waitFn(pattern, status.flags))) {
+            setTimeout(loop, 500);
+          } else {
+            resolve(status);
+          }
+        } catch (e) {
+          debugLog(`Wait error: ${e}`);
+          reject(e);
+        }
+      };
+      setTimeout(loop, 500);
+    });
+  }
+
+  async privateListReports() {
+    return listDirFiles(this.reportPath, /\.XML$/i);
+  }
+
+  async read(progress) {
+    let s = await this.privateReadStatus();
+    const initialReports = await this.privateListReports();
+
+    debugLog(`Start state: ${s.flags}`);
+    if (!_.isEqual(s.flags, ['AUTOSCAN'])) {
+      if (_.includes(s.flags, 'SCAN')) {
+        // Fall through, it's okay if scan was already started
+        // unless we are already in conversion phase.
+        debugLog('Already scanning...');
+      }
+      if (_.includes(s.flags, 'IPREQUEST') || privateIsInStatus(/FOUND\(/, s.flags)) {
+        // FOUND could perhaps fall through, but not sure what the device is doing already.
+        // IPREQUEST might be present if previous read was interrupted. To resolve,
+        // device needs to be reset. (Report erase would also resolve this...)
+        throw new Error('Device busy');
+      }
+      if (_.includes(s.flags, 'NOSCAN')) {
+        progress(1);
+        // Start read.
+        await this.privateLowRead();
+        // Wait for SCAN to activate.
+        s = await this.privateWaitStatus(s.version, 'SCAN');
+      }
+    }
+
+    progress(2);
+    // SCAN might include FOUND already, but if not, wait for the device to be found.
+    if (privateIsNotInStatus(/FOUND\(/, s.flags)) {
+      debugLog('Start data transfer');
+      s = await this.privateWaitStatus(s.version, /FOUND\(|E-.+/);
+      if (privateIsInStatus(/E-.+/, s.flags)) {
+        log(`Error: ${s.flags}`);
+        if (_.includes(s.flags, 'SCAN')) {
+          // So we have SCAN and error simultaneously. Maybe we'll find something?
+          s = await this.privateWaitStatus(s.version, /FOUND\(|NOSCAN/);
+          if (_.includes(s.flags, 'NOSCAN')) {
+            // Scan stopped. Gave up.
+            throw new Error('No device found.');
+          }
+        } else {
+          // Error and no indication of other work.
+          throw new Error('No device found?');
+        }
+      }
+    } else {
+      debugLog('Already transferring');
+    }
+
+    progress(3);
+    let progressVal = 5;
+    // Reading the device into reader.
+    // This wait takes a while.
+    s = await this.privateWaitStatus(s.version, /IPREQUEST|IPREPORT|E-.+/, undefined, () => {
+      if (progressVal < 100) {
+        progress(progressVal);
+        progressVal += 1;
+      }
+    });
+    if (privateIsInStatus(/E-.+/, s.flags)) {
+      // Read was probably interrupted.
+      log(`Read error: ${s.flags}`);
+      throw new Error('Read error');
+    }
+    if (!_.includes(s.flags, 'IPREPORT') && _.includes(s.flags, 'IPREQUEST')) {
+      // Read completed, reader converts the data.
+      progress(progressVal + 1);
+      s = await this.privateWaitStatus(s.version);
+    }
+
+    if (privateIsInStatus(/E-.+/, s.flags)) {
+      // Conversion failed?
+      log(`Reader error: ${s.flags}`);
+      throw new Error('Reader error');
+    }
+    if (_.includes(s.flags, 'IPREPORT')) {
+      progress(99);
+      const reports = await this.privateListReports();
+      const newReports = privateDiffReportLists(initialReports, reports);
+      progress(100);
+      debugLog(`New reports: ${newReports}`);
+      if (newReports.length !== 1) {
+        throw new Error(`Unexpected amount of reports: ${newReports.length}`);
+      } else {
+        return newReports[0];
+      }
+    } else {
+      log(`Unknown status: ${s.flags}`);
+      throw new Error('Unknown status');
+    }
+  }
+
+  /**
+   * Process report data file.
+   *
+   * @param dataFile {string} Base name of the report XML file.
+   * @param progress {Function} Progress callback.
+   * @returns {Promise<Object>} The report data from parser: `.metadata` and `.records[]`.
+   */
+  async process(dataFile, progress) {
+    progress(0);
+    const parser = xml.Parser({
+      explicitChildren: true,
+      preserveChildrenOrder: true,
+    });
+    const fullPath = path.join(this.reportPath, dataFile);
+    const buffer = await fs.readFile(fullPath, { encoding: 'utf-8' });
+    progress(25);
+    const result = await new Promise((resolve, reject) => {
+      try {
+        parser.parseString(buffer, (error, doc) => {
+          if (error) {
+            reject(error);
+          } else {
+            resolve(doc);
+          }
+        });
+      } catch (e) {
+        reject(e);
+      }
+    });
+    progress(50);
+    const data = parsePumpData(result);
+    progress(100);
+    return data;
+  }
+}
+
+function grepDeviceFromDrives(cb) {
+  const drivelist = require('drivelist');
+  drivelist.list().then((drives) => {
+    const smartPixes = _.filter(drives, (d) => d.busType === 'USB' && d.description.indexOf('SMART_PIX') >= 0);
+    const mountedSmartPixes = _.filter(smartPixes, (d) => d.mountpoints.length === 1);
+
+    if (smartPixes.length === 0) {
+      cb(new Error('No SmartPix device found.'));
+    } else if (mountedSmartPixes.length === 0) {
+      cb(new Error('SmartPix device must be mounted first.'));
+    } else if (mountedSmartPixes.length > 1) {
+      cb(new Error('Multiple SmartPix devices found.'));
+    } else {
+      cb(null, smartPixes[0]);
+    }
+  }, (err) => {
+    cb(err);
+  });
+}
+
+async function testPathIsDir(pathName) {
+  const stat = await fs.stat(pathName);
+  if (!stat.isDirectory()) {
+    throw new Error(`Path is not a directory: ${pathName}`);
+  }
+}
+
+module.exports = (config) => {
+  const cfg = _.clone(config);
+  const driver = new AccuChekSmartPix(cfg);
+
+  cfg.deviceInfo.manufacturers = ['Roche'];
+  cfg.tzoUtil = new TZOUtil(cfg.timezone, new Date().toISOString(), []); // FIXME
+  return {
+    /* eslint no-param-reassign:
+       [ "error", { "props": true, "ignorePropertyModificationsFor": ["data", "deviceInfo"] } ] */
+
+    detect(deviceInfo, cb) {
+      grepDeviceFromDrives((grepErr, driveInfo) => {
+        if (grepErr) {
+          log(grepErr);
+          cb(grepErr);
+        } else {
+          const mpPath = driveInfo.mountpoints[0].path;
+          (async () => {
+            try {
+              await testPathIsDir(path.join(mpPath, 'MISC'));
+              log(`Found SmartPix in ${mpPath}`);
+              deviceInfo.path = mpPath;
+              cb(null, deviceInfo);
+            } catch (dirErr) {
+              log(dirErr);
+              cb(dirErr);
+            }
+          })();
+        }
+      });
+    },
+
+    setup(deviceInfo, progress, cb) {
+      progress(10);
+
+      driver.setup(deviceInfo);
+      cb(null, { deviceInfo });
+    },
+
+    connect(deviceInfo, data, cb) {
+      cb(null, data);
+    },
+
+    getConfigInfo(progress, data, cb) {
+      data.stage = 'config';
+      cb(null, data);
+    },
+
+    fetchData(progress, data, cb) {
+      data.stage = 'fetch';
+      (async () => {
+        try {
+          if (QUICK_SINGLE_REPORT) {
+            // This path will short-circuit a single report to the result
+            // to avoid waiting for a long re-read to complete.
+            const files = await driver.privateListReports();
+            if (files.length === 1) {
+              data.dataFile = files[0].name;
+              cb(null, data);
+              return;
+            }
+          }
+
+          data.dataFile = await driver.read(progress);
+          cb(null, data);
+        } catch (e) {
+          log(e);
+          cb(e);
+        }
+      })();
+    },
+
+    processData(progress, data, cb) {
+      data.stage = 'process';
+      (async () => {
+        try {
+          const result = await driver.process(data.dataFile, progress);
+          data.records = result.records;
+          data.deviceInfo.serialNumber = result.metadata.serialNumber;
+          data.deviceInfo.model = result.metadata.model;
+          data.deviceInfo.tags = result.metadata.tags;
+          data.deviceInfo.deviceId = result.metadata.deviceId;
+          debugLog(data);
+          cb(null, data);
+        } catch (e) {
+          log(e);
+          cb(e);
+        }
+      })();
+    },
+
+    uploadData(progress, data, cb) {
+      data.stage = 'upload';
+
+      const sessionInfo = {
+        deviceTags: cfg.deviceInfo.tags,
+        deviceManufacturers: cfg.deviceInfo.manufacturers,
+        deviceModel: cfg.deviceInfo.model,
+        deviceSerialNumber: cfg.deviceInfo.serialNumber,
+        deviceTime: cfg.deviceInfo.deviceTime, // FIXME
+        deviceId: cfg.deviceInfo.deviceId,
+        start: sundial.utcDateString(),
+        timeProcessing: cfg.tzoUtil.type,
+        tzName: cfg.timezone,
+        version: cfg.version,
+      };
+
+      if (cfg.deviceInfo.annotations) {
+        annotate.annotateEvent(sessionInfo, cfg.deviceInfo.annotations);
+      }
+      log('To platform');
+      cfg.api.upload.toPlatform(
+        data.records, sessionInfo, progress, cfg.groupId,
+        (err, result) => {
+          progress(100);
+
+          if (err) {
+            log(err);
+            log(result);
+            return cb(err, data);
+          }
+          return cb(null, data);
+        },
+        'dataservices',
+      );
+    },
+
+    disconnect(progress, data, cb) {
+      data.stage = 'disconnect';
+      cb(null, data);
+    },
+
+    cleanup(progress, data, cb) {
+      data.stage = 'cleanup';
+      cb(null, data);
+    },
+  };
+};
+
+module.exports.Driver = AccuChekSmartPix;

--- a/lib/drivers/roche/smartpix/accuChekSmartPixCommonXML.js
+++ b/lib/drivers/roche/smartpix/accuChekSmartPixCommonXML.js
@@ -1,0 +1,98 @@
+import sundial from 'sundial';
+import _ from 'lodash';
+
+const isBrowser = typeof window !== 'undefined';
+
+// eslint-disable-next-line
+export const log = isBrowser ? require('bows')('AccuChekSmartPixDriver') : console.log;
+
+export const ALARM_TYPES = {
+  W1: 'low_insulin',
+  E1: 'no_insulin',
+  W2: 'low_battery',
+  E2: 'no_battery',
+  E3: 'auto_off',
+  E4: 'occlusion',
+};
+/*
+Other alarms:
+W3: Check time.
+W4: Device old. (6y)
+W5: Loan-time ending soon (in 30d).
+W6: TBA cancelled.
+W7: TBA ended.
+W8: Bolus cancelled
+W9: Loan-time ending soon.
+W10: Bluetooth problem.
+E5: Loan-time ended.
+E6: Mechanic problem.
+E7: Electronic problem.
+E8: Power failure.
+E9: Loan-time ended.
+E10: Ampulla problem.
+E11: Cathether not filled.
+E12: Ongoing data transfer.
+E13: Language error.
+R1: Own reminder.
+R2: Warranty expired. (4y)
+*/
+
+const DATE_FORMAT = /^(\d+)-(\d+)-(\d+)$/;
+const TIME_FORMAT = /^(\d+):(\d+)$/;
+
+export function parseDtTm(entry) {
+  const dt = DATE_FORMAT.exec(entry.Dt);
+  const tm = TIME_FORMAT.exec(entry.Tm);
+  if (!dt || !tm) {
+    throw new Error('Date or time format was not understood.');
+  }
+
+  return sundial.buildTimestamp({
+    year: dt[1],
+    month: dt[2],
+    day: dt[3],
+    hours: tm[1],
+    minutes: tm[2],
+    seconds: 0,
+  });
+}
+
+export function makeDebug(state, result, original, related, reason) {
+  if (state.DEBUG && result != null) {
+    const payload = typeof (result.debug) === 'object' ? result.debug : {};
+    payload.originalRow = original;
+    if (related) {
+      payload.relatedRow = related;
+    }
+    if (reason) {
+      _.assign(payload, reason);
+    }
+    _.assign(result, { debug: payload });
+  }
+  return result;
+}
+
+export function newState(state) {
+  if (state) {
+    return {
+      /** Last Run entry used to calculate time for suspension
+       * between Stop and Run. */
+      lastRunEntry: state.lastRunEntry,
+      lastStopEntry: state.lastStopEntry,
+      lastTBREndEntry: state.lastTBREndEntry,
+      lastTBRStartEntry: state.lastTBRStartEntry,
+      lastScheduledTBRChangeEntry: state.lastScheduledTBRChangeEntry,
+      lastBasalEntry: state.lastBasalEntry,
+    };
+  }
+  return {
+    /** Last Run entry used to calculate time for suspension
+     * between Stop and Run. */
+    lastRunEntry: null,
+    lastStopEntry: null,
+    lastTBREndEntry: null,
+    lastTBRStartEntry: null,
+    lastScheduledTBRChangeEntry: null,
+    lastBasalEntry: null,
+  };
+}

--- a/lib/drivers/roche/smartpix/accuChekSmartPixPumpXML.js
+++ b/lib/drivers/roche/smartpix/accuChekSmartPixPumpXML.js
@@ -1,0 +1,211 @@
+import sundial from 'sundial';
+import _ from 'lodash';
+import objectBuilder from '../../../objectBuilder';
+import {
+  ALARM_TYPES, makeDebug, parseDtTm,
+} from './accuChekSmartPixCommonXML';
+import parseBasal from './acspBasal';
+import parseBolusInfo from './acspBolus';
+
+const IU_FORMAT = /^(\d+\.\d+)\s*IU$/;
+
+const PUMP_NAMES = {
+  Combo: 'Spirit / Combo',
+};
+
+function parseEvent(row, state, builder) {
+  const type = row.$.shortinfo;
+  const { description } = row.$;
+
+  let result = null;
+  const alarmType = ALARM_TYPES[type];
+  if (alarmType) {
+    result = builder.makeDeviceEventAlarm()
+      .with_alarmType(alarmType)
+      .with_payload({
+        alarm_id: type,
+        alarm_name: description,
+      });
+  } else if (type) {
+    if (description === 'prime infusion set') {
+      const amountStr = IU_FORMAT.exec(type)[1];
+      result = builder.makeDeviceEventPrime()
+        .with_primeTarget('tubing')
+        .with_volume(Number.parseFloat(amountStr));
+    } else {
+      // Unhandled event type.
+      result = builder.makeDeviceEventAlarm()
+        .with_alarmType('other')
+        .with_payload({
+          alarm_id: type,
+          alarm_name: description,
+        });
+    }
+  } else if (description === 'cartridge changed') {
+    result = builder.makeDeviceEventReservoirChange();
+  }
+  if (result) {
+    result = makeDebug(state, result, row);
+  }
+  return result;
+}
+
+function parseHeader(pumpInfo) {
+  const profiles = {};
+  const srcProfiles = pumpInfo.IPPROFILE;
+  const activeProfile = pumpInfo.$.ActiveProf;
+
+  _.forEach(srcProfiles, (profile) => {
+    // Slot list is constant-length. Compress entries using same value to a single entry.
+    const profileData = [];
+    let lastIU = null;
+
+    _.forEach(profile.IPTIMESLOT, (entry) => {
+      const currentIU = entry.$.IU;
+      if (currentIU !== lastIU) {
+        profileData.push({
+          // Number is ending-hour. Convert it to start-hour (and then to milliseconds).
+          start: (Number.parseInt(entry.$.Number, 10) - 1) * 60 * sundial.MIN_TO_MSEC,
+          // IU per hour.
+          // XXX: This value might be bogus as at least SmartPix
+          // version 3.01 truncates the value to 1 decimal.
+          rate: Number.parseFloat(currentIU),
+        });
+        lastIU = currentIU;
+      }
+    });
+    if (profileData.length > 0) {
+      // TODO: Ensure starts are ordered?
+      profiles[profile.$.Name] = profileData;
+    }
+  });
+
+  return {
+    activeProfile,
+    basalSchedules: profiles,
+    serialNumber: _.trim(pumpInfo.$.SN),
+    modelName: _.trim(pumpInfo.$.Name),
+  };
+}
+
+function parseIPData(ipdata, builder) {
+  const state = {
+    /** Last Run entry used to calculate time for suspension
+     * between Stop and Run. */
+    lastRunEntry: null,
+    setLastRunEntry(v) { this.lastRunEntry = v; },
+
+    lastStopEntry: null,
+    setLastStopEntry(v) { this.lastStopEntry = v; },
+
+    lastTBREndEntry: null,
+    setLastTBREndEntry(v) { this.lastTBREndEntry = v; },
+
+    lastTBRStartEntry: null,
+    setLastTBRStartEntry(v) { this.lastTBRStartEntry = v; },
+
+    lastScheduledTBRChangeEntry: null,
+    setLastScheduledTBRChangeEntry(v) { this.lastScheduledTBRChangeEntry = v; },
+
+    lastBasalEntry: null,
+    setLastBasalEntry(v) { this.lastBasalEntry = v; },
+
+    /** Peek-ahead to next row of data. */
+    nextEntry: null,
+    /** Attach debug-key to result objects? */
+    DEBUG: false,
+
+    currentRowIndex: null,
+    getNextTBREntry() {
+      for (let i = state.currentRowIndex + 1; i < ipdata.length; i++) {
+        const row = ipdata[i];
+        if (row.$.TBRinc || row.$.TBRdec) {
+          return row;
+        }
+      }
+      throw new Error('Missing next TBR entry.');
+    },
+  };
+
+  const entries = [];
+  _.forEach(_.keys(ipdata), (indexStr) => {
+    const i = indexStr - 0;
+    const element = ipdata[i];
+    state.nextEntry = ipdata[i + 1] || null;
+    state.currentRowIndex = i;
+
+    const type = element['#name'];
+    let result = null;
+    switch (type) {
+      case 'BOLUS':
+        result = parseBolusInfo(element, state, builder);
+        break;
+      case 'BASAL':
+        result = parseBasal(element, state, builder);
+        break;
+      case 'EVENT':
+        result = parseEvent(element, state, builder);
+        break;
+      default:
+    }
+    if (result !== null) {
+      const time = parseDtTm(element.$);
+      result = result
+        .with_deviceTime(sundial.formatDeviceTime(time))
+        .with_time(sundial.applyTimezone(time, 'Europe/Helsinki')) // FIXME: TZ and conversion
+        .with_timezoneOffset(120) // FIXME: TZ offset
+        .with_clockDriftOffset(0)
+        .with_conversionOffset(0);
+      entries.push(result.done());
+    }
+  });
+  return entries;
+}
+
+/**
+ * Parse pump data from parsed xml document.
+ *
+ * @param document {Object} Document parsed with `xml2js`.
+ * @param cfg {{manufacturers: string}?} Device info.
+ * @param builder {objectBuilder?} Previous objectBuilder.
+ * @returns {{metadata: Object, records: *[]}} Parsed data, ready for API.
+ */
+export function parsePumpData(document, cfg, builder) {
+  const theBuilder = builder || objectBuilder();
+
+  // log(util.inspect(root.IPDATA, false, null));
+  const root = document.IMPORT;
+  const records = [];
+  const header = parseHeader(root.IP[0]);
+
+  const deviceId = `${header.modelName}:${header.serialNumber}`;
+  theBuilder.setDefaults({ deviceId });
+
+  if (cfg) {
+    const currentSettings = theBuilder.makePumpSettings()
+      .with_manufacturers(cfg.manufacturers)
+      .with_serialNumber(header.serialNumber)
+      // TODO: We really don't know. This is a pump, not a bg meter!
+      .with_units({ bg: 'mmol/L', carbs: 'grams' })
+      .with_basalSchedules(header.basalSchedules)
+      .with_activeSchedule(header.activeProfile)
+      .done();
+    records.push(currentSettings);
+  }
+
+  const stream = parseIPData(root.IPDATA[0].$$, theBuilder);
+
+  // log(JSON.stringify(header, null, 2));
+  // log(JSON.stringify(stream, null, 2));
+  // log(util.inspect(basal, false, null));
+  return {
+    metadata: {
+      modelName: header.modelName,
+      model: PUMP_NAMES[header.modelName] || header.modelName,
+      serialNumber: header.serialNumber,
+      tags: ['insulin-pump'],
+      deviceId,
+    },
+    records: records.concat(stream),
+  };
+}

--- a/lib/drivers/roche/smartpix/acspBasal.js
+++ b/lib/drivers/roche/smartpix/acspBasal.js
@@ -1,0 +1,223 @@
+import _ from 'lodash';
+import sundial from 'sundial';
+import {
+  ALARM_TYPES, log, makeDebug, parseDtTm,
+} from './accuChekSmartPixCommonXML';
+
+const TBR_REMARK_PATTERN = /^dur (\d+):(\d+) h$/;
+const TBR_PERCENT_PATTERN = /^\s*(\d+)%$/;
+
+function mostRecentBasalAlteringEntry(state) {
+  const entries = [
+    state.lastBasalEntry,
+    state.lastStopEntry,
+    state.lastTBRStartEntry,
+    state.lastScheduledTBRChangeEntry,
+  ];
+  const times = _.map(entries, (e) => {
+    if (e != null) {
+      return parseDtTm(e.$).valueOf();
+    }
+    return null;
+  });
+
+  let minValue = Number.MAX_VALUE;
+  let minIndex = -1;
+  _.forEach(times, (e, index) => {
+    if (e != null && e < minValue) {
+      minValue = e;
+      minIndex = index;
+    }
+  });
+
+  if (minIndex >= 0) {
+    return entries[minIndex];
+  }
+  return null;
+}
+
+function makeBasalEntry(state, row, builder) {
+  const closestEntry = mostRecentBasalAlteringEntry(state);
+  if (closestEntry == null) {
+    log(state);
+    log(row);
+    throw new Error('Missing closest entry for basal duration calculation');
+  }
+
+  const time = parseDtTm(row.$);
+  const closestTimestamp = parseDtTm(closestEntry.$);
+  const duration = sundial.dateDifference(closestTimestamp, time, 'minutes');
+  const result = builder.makeScheduledBasal()
+    .with_rate(Number.parseFloat(row.$.cbrf))
+    .with_duration(duration * sundial.MIN_TO_MSEC)
+    .with_scheduleName(row.$.profile);
+  return makeDebug(state, result, row, closestEntry);
+}
+
+export default function parseBasal(row, state, builder) {
+  const { remark } = row.$;
+  const time = parseDtTm(row.$);
+  let result = null;
+
+  if (remark) {
+    switch (remark) {
+      case 'Run':
+        if (state.lastRunEntry != null) {
+          log(state.lastRunEntry);
+          log(row);
+          throw new Error('Double Run?');
+        }
+        result = makeBasalEntry(state, row, builder);
+        state.setLastRunEntry(row);
+        state.setLastStopEntry(null);
+        break;
+
+      case 'Stop': {
+        // XXX: Stop basal event might contain TBRinc or TBRdec attribute,
+        // which is probably useless since in that case this row was
+        // preceded by "TBR End (cancelled)" basal event.
+        if (state.lastRunEntry == null) {
+          // Data stream contains a "Stop" event in few first lines, as
+          // device needs to be stopped for data transfer. We don't
+          // have Run entry to pair it with, and so we can't calculate
+          // required duration for the suspension. Ignore this event...
+          state.setLastStopEntry(row);
+          break;
+        }
+
+        let suspendReason;
+        let suspendPayload = null;
+        let reason = null;
+        const { nextEntry } = state;
+
+        if (nextEntry != null && nextEntry['#name'] === 'EVENT') {
+          const nextTime = parseDtTm(nextEntry.$);
+          const nextShort = nextEntry.$.shortinfo;
+
+          if (nextTime.valueOf() === time.valueOf()
+            && _.startsWith(nextShort, 'E') && nextShort.length <= 3) {
+            reason = nextEntry;
+            suspendReason = 'automatic';
+            const alarmType = ALARM_TYPES[nextEntry.$.type] || 'other';
+            suspendPayload = {
+              suspended: {
+                cause: 'alarm',
+                alarm_type: alarmType,
+                alarm_id: nextShort,
+                alarm_name: nextEntry.$.description,
+              },
+            };
+          } else {
+            suspendReason = 'manual';
+          }
+        } else {
+          suspendReason = 'manual';
+        }
+
+        const runTimestamp = parseDtTm(state.lastRunEntry.$);
+        const stopLengthMinutes = sundial.dateDifference(runTimestamp, time, 'minutes');
+        result = builder.makeDeviceEventSuspendResume()
+          .with_duration(stopLengthMinutes * sundial.MIN_TO_MSEC)
+          .with_reason({
+            // Accu-Check pumps do not automatically resume.
+            resumed: 'manual',
+            suspended: suspendReason,
+          });
+        if (suspendPayload) {
+          result = result.with_payload(suspendPayload);
+        }
+        result = makeDebug(state, result, row, state.lastRunEntry,
+          { reason });
+
+        // Processing done. Clear until next Run.
+        state.setLastRunEntry(null);
+        state.setLastStopEntry(row);
+
+        break;
+      }
+
+      case 'power up':
+        break;
+
+      case 'power down':
+        break;
+
+      case 'TBR End':
+      case 'TBR End (cancelled)':
+        if (state.lastTBREndEntry != null) {
+          log(state.lastTBREndEntry);
+          log(row);
+          throw new Error('Unexpected TBR End record');
+        }
+        result = makeBasalEntry(state, row, builder);
+        state.setLastTBREndEntry(row);
+        break;
+
+      default:
+        if (_.startsWith(remark, 'dur') && (row.$.TBRinc || row.$.TBRdec)) {
+          // TBR Start entry.
+          if (state.lastTBREndEntry == null) {
+            log(row);
+            throw new Error('Missing TBR End record');
+          }
+          const tbr = (row.$.TBRinc || row.$.TBRdec);
+
+          const previousEntry = (state.lastScheduledTBRChangeEntry || state.lastTBREndEntry);
+          const endTimestamp = parseDtTm(previousEntry.$);
+          const currentRateTbrLengthMinutes = sundial.dateDifference(endTimestamp, time, 'minutes');
+          const tbrTotalLength = sundial.dateDifference(parseDtTm(state.lastTBREndEntry.$), time, 'minutes');
+          const remarkLengthMatch = TBR_REMARK_PATTERN.exec(remark);
+          const remarkLength = Number.parseInt(remarkLengthMatch[1], 10) * 60
+            + Number.parseInt(remarkLengthMatch[2], 10);
+          if (remarkLength !== tbrTotalLength) {
+            log(`Differing TBR remark ${remarkLength} and actual times ${tbrTotalLength}.`);
+          }
+
+          const rate = Number.parseFloat(row.$.cbrf);
+          const percents = Number.parseInt(TBR_PERCENT_PATTERN.exec(tbr)[1], 10);
+
+          result = builder.makeTempBasal()
+            .with_percent(percents / 100.0)
+            .with_rate(rate)
+            .with_duration(currentRateTbrLengthMinutes * sundial.MIN_TO_MSEC);
+          result = makeDebug(state, result, row, state.lastTBREndEntry);
+
+          state.setLastTBRStartEntry(row);
+          state.setLastTBREndEntry(null);
+          state.setLastScheduledTBRChangeEntry(null);
+        }
+        break;
+    }
+  } else if (row.$.TBRinc || row.$.TBRdec) {
+    // Incomplete TBR entry due profile basal rate change.
+    const tbrStart = state.getNextTBREntry();
+    const previousEntry = (state.lastScheduledTBRChangeEntry || state.lastTBREndEntry);
+
+    const tbr = (row.$.TBRinc || row.$.TBRdec);
+    const endTimestamp = parseDtTm(previousEntry.$);
+    const tbrLengthMinutes = sundial.dateDifference(endTimestamp, time, 'minutes');
+    const rate = Number.parseFloat(row.$.cbrf);
+    // XXX: percents might be bogus since SmartPix 3.01 might mess it up.
+    const rowPercents = Number.parseInt(TBR_PERCENT_PATTERN.exec(tbr)[1], 10);
+
+    const realPercents = Number.parseInt(TBR_PERCENT_PATTERN.exec(
+      tbrStart.$.TBRinc || tbrStart.$.TBRdec,
+    )[1], 10);
+    if (rowPercents !== realPercents) {
+      log(`Differing TBR percents ${rowPercents} with start percents ${realPercents}.`);
+    }
+
+    result = builder.makeTempBasal()
+      .with_percent(realPercents / 100.0)
+      .with_rate(rate)
+      .with_duration(tbrLengthMinutes * sundial.MIN_TO_MSEC);
+    result = makeDebug(state, result, row, previousEntry,
+      { start: tbrStart });
+
+    state.setLastScheduledTBRChangeEntry(row);
+  } else if (row.$.cbrf && row.$.profile) {
+    result = makeBasalEntry(state, row, builder);
+    state.setLastBasalEntry(row);
+  }
+  return result;
+}

--- a/lib/drivers/roche/smartpix/acspBolus.js
+++ b/lib/drivers/roche/smartpix/acspBolus.js
@@ -1,0 +1,81 @@
+import sundial from 'sundial';
+import { log, makeDebug } from './accuChekSmartPixCommonXML';
+
+const BOLUS_EXT_REMARK = /^\s?(\d+):(\d+) h$/;
+const BOLUS_MUL_REMARK = /^\s?(\d+\.\d+) \/ (\d+\.\d+)\s+(\d+):(\d+) h$/;
+const BOLUS_EPSILON = 0.00001;
+
+export default function parseBolusInfo(row, state, builder) {
+  const { type } = row.$;
+
+  if (row.$.Tm === '' && row.$.remark.indexOf('Total') >= 0) {
+    // Ignore daily totals.
+    return null;
+  }
+
+  let result = null;
+  switch (type) {
+    case 'Scr':
+    case 'Std': {
+      const amount = Number.parseFloat(row.$.amount);
+
+      if (amount > BOLUS_EPSILON) {
+        result = builder.makeNormalBolus()
+          .with_normal(amount);
+      } else {
+        // We do not have expected size for the bolus and zero-bolus
+        // without expected size is disallowed. We could perhaps store
+        // previous bolus and check if it is close enough to this one
+        // and set its value to expected value, but that's heuristics.
+        log('Dropping zero-sized bolus:');
+        log(row);
+      }
+      break;
+    }
+
+    case 'Ext': {
+      const remark = BOLUS_EXT_REMARK.exec(row.$.remark);
+      const amount = Number.parseFloat(row.$.amount);
+      const durationMinutes = Number.parseInt(remark[1], 10) * 60 + Number.parseInt(remark[2], 10);
+
+      if (amount > BOLUS_EPSILON) {
+        result = builder.makeSquareBolus()
+          .with_extended(amount)
+          .with_duration(durationMinutes * sundial.MIN_TO_MSEC);
+      } else {
+        // Not allowed, see above.
+        log('Dropping zero-sized bolus:');
+        log(row);
+      }
+      break;
+    }
+
+    case 'Mul': {
+      const remark = BOLUS_MUL_REMARK.exec(row.$.remark);
+      const normalAmount = Number.parseFloat(remark[1]);
+      const extendedAmount = Number.parseFloat(remark[2]);
+      const extendedDuration = Number.parseInt(remark[3], 10) * 60 + Number.parseInt(remark[4], 10);
+
+      if (normalAmount > BOLUS_EPSILON || extendedAmount > BOLUS_EPSILON) {
+        result = builder.makeDualBolus()
+          .with_normal(normalAmount)
+          .with_extended(extendedAmount)
+          .with_duration(extendedDuration * sundial.MIN_TO_MSEC);
+      } else {
+        // Not allowed, see above.
+        log('Dropping zero-sized bolus:');
+        log(row);
+      }
+      break;
+    }
+
+    default:
+      log(`Unexpected bolus type: ${type}`);
+      break;
+  }
+
+  if (result) {
+    result = makeDebug(state, result, row);
+  }
+  return result;
+}

--- a/package.json
+++ b/package.json
@@ -85,7 +85,8 @@
     "tidepool-platform-client": "0.44.0",
     "usb-cdc-acm": "0.1.1",
     "uuid": "7.0.3",
-    "webmtp": "0.1.0"
+    "webmtp": "0.1.0",
+    "xml2js": "0.4.19"
   },
   "browserslist": "last 2 electron major versions",
   "bin": {


### PR DESCRIPTION
This version supports only model 1 / gray SmartPix readers, reading
insulin pumps.
The reader must be attached and mounted (it shows as mass storage
device) before reading is started.

The XML part expects the document to be read with xml2js.
The pump data parser understands only name of Spirit/Combo pump, but
assuming that it is the reader that generates the report format, it
should handle other pumps too.

The parser understands data generated by Smart Pix 1 firmwares 3.01.03
and 3.05.01, but others should work too.